### PR TITLE
Removed root user dependency, added PAM authentication

### DIFF
--- a/main.go
+++ b/main.go
@@ -42,10 +42,6 @@ func init() {
 func main() {
 	cfg := parseConfig()
 
-	if os.Getuid() > 0 && cfg.username == "" {
-		log.Error("Operation not permitted. Please start as root or define Username and Password in configuration file")
-		os.Exit(1)
-	}
 
 	log.Info("Go Version: ", runtime.Version())
 	log.Info("Go OS/Arch: ", runtime.GOOS, "/", runtime.GOARCH)

--- a/pwauth/auth_linux.go
+++ b/pwauth/auth_linux.go
@@ -2,56 +2,33 @@ package pwauth
 
 import (
 	"errors"
-	"io/ioutil"
-	"os"
-	"os/user"
-	"strings"
-
-	"github.com/GehirnInc/crypt"
-	_ "github.com/GehirnInc/crypt/apr1_crypt"
-	_ "github.com/GehirnInc/crypt/md5_crypt"
-	_ "github.com/GehirnInc/crypt/sha256_crypt"
-	_ "github.com/GehirnInc/crypt/sha512_crypt"
+	"fmt"
+	"github.com/msteinert/pam"
 )
 
-func getPassword(name string) (string, error) {
-	/* Disallow potentially-malicious user names */
-	if name == "" || name[0] == '.' || strings.Contains(name, "/") {
-		return "", errors.New("Invalid")
-	}
-
-	data, err := ioutil.ReadFile("/etc/shadow")
-	if err != nil {
-		return "", err
-	}
-
-	for _, l := range strings.Split(string(data), "\n") {
-		if !strings.HasPrefix(l, name+":") {
-			continue
-		}
-
-		s := strings.Split(l, ":")
-
-		return s[1], nil
-	}
-
-	return "", errors.New("Not found")
-}
-
 func auth(username, password string) error {
-	if os.Getuid() != 0 {
-		return errors.New("Cannot possibly work without effective root")
+    t, err := pam.StartFunc("rttys", username, func(s pam.Style, msg string) (string, error) {
+	switch s {
+	case pam.PromptEchoOff:
+	    return password, nil
+	case pam.PromptEchoOn:
+	    return password, nil
+	case pam.ErrorMsg:
+	    fmt.Print(msg)
+	    return "", nil
+	case pam.TextInfo:
+	    fmt.Println(msg)
+	    return "", nil
 	}
-
-	if _, err := user.Lookup(username); err != nil {
-		return err
-	}
-
-	pw, err := getPassword(username)
-	if err != nil {
-		return err
-	}
-
-	c := crypt.NewFromHash(pw)
-	return c.Verify(pw, []byte(password))
+	return "", errors.New("Unrecognized message style")
+    })
+    if err != nil {
+	return err
+    }
+    err = t.Authenticate(0)
+    if err != nil {
+	return err
+    }
+    //fmt.Println("Authentication succeeded!")
+    return nil
 }


### PR DESCRIPTION
Example PAM file in /etc/pam.d/rttys, to check if the user given is member of
any groups listed in the /etc/rttys/groups.allowed file. Uses SSSD for auth.

auth        requisite      pam_listfile.so onerr=fail item=group sense=allow file=/etc/rttys/groups.allowed
auth        required      pam_sss.so forward_pass

account     [default=bad success=ok user_unknown=ignore] pam_sss.so