### PR TITLE
Fix for the build.sh

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -9,6 +9,7 @@ generate() {
 	local arch="$2"
 	local dir="rttys-$os-$arch"
 	local bin="rttys"
+	local cgo=0
 
 	mkdir output/$dir
 	cp rttys.conf output/$dir
@@ -18,7 +19,11 @@ generate() {
 		bin="rttys.exe"
 	}
 
-	GOOS=$os GOARCH=$arch CGO_ENABLED=0 go build -ldflags="-s -w -X $VersionPath.gitCommit=$GitCommit -X $VersionPath.buildTime=$BuildTime" -o output/$dir/$bin
+	[ "$os" = "linux" ] && {
+		cgo=1
+	}
+
+	GOOS=$os GOARCH=$arch CGO_ENABLED=$cgo go build -ldflags="-s -w -X $VersionPath.gitCommit=$GitCommit -X $VersionPath.buildTime=$BuildTime" -o output/$dir/$bin
 
 	cd output
 


### PR DESCRIPTION
PAM introduced a dependency and need to build with CGO_ENABLED=1.

Make sure you have pam-devel and glibc-devel for both 64 and 32 bit architecture.

On a 64bit Fedora/Redhat:
  dnf install glibc-devel.i686 pam-devel.i686 glibc-devel pam-devel

Fixes: https://github.com/zhaojh329/rttys/pull/31#issuecomment-549051635