### PR TITLE
update `html` to `ui` and add `node` version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node
+FROM node:16
 WORKDIR /build
 COPY ./ui ./
 RUN  npm install && npm run build

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM node
 WORKDIR /build
-COPY ./html ./
+COPY ./ui ./
 RUN  npm install && npm run build
 
 FROM golang:alpine


### PR DESCRIPTION
I found that the front-end directory is updated to `ui`, but the Dockerfile file is still `html`;
`node` current latest version is  `17.2.0` ,  use `16.x` versions to build successfully;