### PR TITLE
tls 1.2以下版本有安全漏洞。需要最低版本是tls 1.2

### DIFF
--- a/device.go
+++ b/device.go
@@ -367,6 +367,7 @@ func listenDevice(br *broker) {
 		tlsConfig.Certificates = []tls.Certificate{crt}
 		tlsConfig.Time = time.Now
 		tlsConfig.Rand = rand.Reader
+		tlsConfig.MinVersion = tls.VersionTLS12
 
 		if cfg.SslCacert == "" {
 			log.Warn().Msgf("mTLS not enabled")


### PR DESCRIPTION
tls 1.1 有安全漏洞