### PR TITLE
Separate SSL Configurations for Device and Web UI

### DIFF
--- a/api.go
+++ b/api.go
@@ -621,9 +621,9 @@ func apiStart(br *broker) {
 	go func() {
 		var err error
 
-		if cfg.SslCert != "" && cfg.SslKey != "" {
+		if cfg.WebUISslCert != "" && cfg.WebUISslKey != "" {
 			log.Info().Msgf("Listen user on: %s SSL on", cfg.AddrUser)
-			err = r.RunTLS(cfg.AddrUser, cfg.SslCert, cfg.SslKey)
+			err = r.RunTLS(cfg.AddrUser, cfg.WebUISslCert, cfg.WebUISslKey)
 		} else {
 			log.Info().Msgf("Listen user on: %s SSL off", cfg.AddrUser)
 			err = r.Run(cfg.AddrUser)

--- a/config/config.go
+++ b/config/config.go
@@ -20,6 +20,8 @@ type Config struct {
 	SslCert           string
 	SslKey            string
 	SslCacert         string // mTLS for device
+	WebUISslCert       string
+	WebUISslKey        string
 	Token             string
 	WhiteList         map[string]bool
 	DB                string
@@ -50,6 +52,8 @@ func Parse(c *cli.Context) *Config {
 		SslCert:           c.String("ssl-cert"),
 		SslKey:            c.String("ssl-key"),
 		SslCacert:         c.String("ssl-cacert"),
+		WebUISslCert:       c.String("webui-ssl-cert"),
+		WebUISslKey:        c.String("webui-ssl-key"),
 		Token:             c.String("token"),
 		DB:                c.String("db"),
 		LocalAuth:         c.Bool("local-auth"),
@@ -76,6 +80,8 @@ func Parse(c *cli.Context) *Config {
 		getConfigOpt(yamlCfg, "ssl-cert", &cfg.SslCert)
 		getConfigOpt(yamlCfg, "ssl-key", &cfg.SslKey)
 		getConfigOpt(yamlCfg, "ssl-cacert", &cfg.SslCacert)
+		getConfigOpt(yamlCfg, "webui-ssl-cert", &cfg.WebUISslCert)
+		getConfigOpt(yamlCfg, "webui-ssl-key", &cfg.WebUISslKey)
 		getConfigOpt(yamlCfg, "token", &cfg.Token)
 		getConfigOpt(yamlCfg, "db", &cfg.DB)
 		getConfigOpt(yamlCfg, "local-auth", &cfg.LocalAuth)

--- a/rttys.conf
+++ b/rttys.conf
@@ -9,6 +9,8 @@
 #ssl-cacert: /etc/rttys/rttys.ca
 #ssl-cert: /etc/rttys/rttys.crt
 #ssl-key: /etc/rttys/rttys.key
+#webui-ssl-cert: /etc/rttys/webui-rttys.crt
+#webui-ssl-key: /etc/rttys/webui-rttys.key
 
 #token: a1d4cdb1a3cd6a0e94aa3599afcddcf5
 


### PR DESCRIPTION
By separating the SSL configurations, we can better manage security protocols tailored to the specific needs of the device and web UI, improving overall security posture.