### PR TITLE
Separate SSL Configurations for Device and User

### DIFF
--- a/api.go
+++ b/api.go
@@ -621,9 +621,9 @@ func apiStart(br *broker) {
 	go func() {
 		var err error
 
-		if cfg.SslCert != "" && cfg.SslKey != "" {
+		if cfg.WebUISslCert != "" && cfg.WebUISslKey != "" {
 			log.Info().Msgf("Listen user on: %s SSL on", cfg.AddrUser)
-			err = r.RunTLS(cfg.AddrUser, cfg.SslCert, cfg.SslKey)
+			err = r.RunTLS(cfg.AddrUser, cfg.WebUISslCert, cfg.WebUISslKey)
 		} else {
 			log.Info().Msgf("Listen user on: %s SSL off", cfg.AddrUser)
 			err = r.Run(cfg.AddrUser)

--- a/config/config.go
+++ b/config/config.go
@@ -26,6 +26,7 @@ type Config struct {
 	WhiteList         map[string]bool
 	DB                string
 	LocalAuth         bool
+	SeparateSslConfig bool
 }
 
 func getConfigOpt(yamlCfg *yaml.File, name string, opt interface{}) {
@@ -54,6 +55,7 @@ func Parse(c *cli.Context) *Config {
 		SslCert:           c.String("ssl-cert"),
 		SslKey:            c.String("ssl-key"),
 		SslCacert:         c.String("ssl-cacert"),
+		SeparateSslConfig: c.Bool("separate-ssl-config"),
 		WebUISslCert:       c.String("webui-ssl-cert"),
 		WebUISslKey:        c.String("webui-ssl-key"),
 		Token:             c.String("token"),
@@ -82,12 +84,17 @@ func Parse(c *cli.Context) *Config {
 		getConfigOpt(yamlCfg, "ssl-cert", &cfg.SslCert)
 		getConfigOpt(yamlCfg, "ssl-key", &cfg.SslKey)
 		getConfigOpt(yamlCfg, "ssl-cacert", &cfg.SslCacert)
-		getConfigOpt(yamlCfg, "webui-ssl-cert", &cfg.WebUISslCert)
-		getConfigOpt(yamlCfg, "webui-ssl-key", &cfg.WebUISslKey)
+		getConfigOpt(yamlCfg, "separate-ssl-config", &cfg.SeparateSslConfig)
+		if cfg.SeparateSslConfig {
+			getConfigOpt(yamlCfg, "webui-ssl-cert", &cfg.WebUISslCert)
+			getConfigOpt(yamlCfg, "webui-ssl-key", &cfg.WebUISslKey)
+		} else {
+			cfg.WebUISslCert = cfg.SslCert
+			cfg.WebUISslKey = cfg.SslKey
+		}
 		getConfigOpt(yamlCfg, "token", &cfg.Token)
 		getConfigOpt(yamlCfg, "db", &cfg.DB)
 		getConfigOpt(yamlCfg, "local-auth", &cfg.LocalAuth)
-
 		val, err := yamlCfg.Get("white-list")
 		if err == nil {
 			if val == "*" || val == "\"*\"" {

--- a/config/config.go
+++ b/config/config.go
@@ -39,6 +39,8 @@ func getConfigOpt(yamlCfg *yaml.File, name string, opt interface{}) {
 		*opt = val
 	case *int:
 		*opt, _ = strconv.Atoi(val)
+	case *bool:
+		*opt, _ = strconv.ParseBool(val)
 	}
 }
 

--- a/config/config.go
+++ b/config/config.go
@@ -20,6 +20,8 @@ type Config struct {
 	SslCert           string
 	SslKey            string
 	SslCacert         string // mTLS for device
+	WebUISslCert       string
+	WebUISslKey        string
 	Token             string
 	WhiteList         map[string]bool
 	DB                string
@@ -50,6 +52,8 @@ func Parse(c *cli.Context) *Config {
 		SslCert:           c.String("ssl-cert"),
 		SslKey:            c.String("ssl-key"),
 		SslCacert:         c.String("ssl-cacert"),
+		WebUISslCert:       c.String("webui-ssl-cert"),
+		WebUISslKey:        c.String("webui-ssl-key"),
 		Token:             c.String("token"),
 		DB:                c.String("db"),
 		LocalAuth:         c.Bool("local-auth"),
@@ -76,6 +80,8 @@ func Parse(c *cli.Context) *Config {
 		getConfigOpt(yamlCfg, "ssl-cert", &cfg.SslCert)
 		getConfigOpt(yamlCfg, "ssl-key", &cfg.SslKey)
 		getConfigOpt(yamlCfg, "ssl-cacert", &cfg.SslCacert)
+		getConfigOpt(yamlCfg, "webui-ssl-cert", &cfg.WebUISslCert)
+		getConfigOpt(yamlCfg, "webui-ssl-key", &cfg.WebUISslKey)
 		getConfigOpt(yamlCfg, "token", &cfg.Token)
 		getConfigOpt(yamlCfg, "db", &cfg.DB)
 		getConfigOpt(yamlCfg, "local-auth", &cfg.LocalAuth)

--- a/rttys.conf
+++ b/rttys.conf
@@ -9,6 +9,9 @@
 #ssl-cacert: /etc/rttys/rttys.ca
 #ssl-cert: /etc/rttys/rttys.crt
 #ssl-key: /etc/rttys/rttys.key
+
+#if you want to use separate SSL config for webui, set this to True.otherwise, it will use the same SSL config for device and webui
+#separate-ssl-config: True
 #webui-ssl-cert: /etc/rttys/webui-rttys.crt
 #webui-ssl-key: /etc/rttys/webui-rttys.key
 

--- a/rttys.conf
+++ b/rttys.conf
@@ -9,6 +9,8 @@
 #ssl-cacert: /etc/rttys/rttys.ca
 #ssl-cert: /etc/rttys/rttys.crt
 #ssl-key: /etc/rttys/rttys.key
+#webui-ssl-cert: /etc/rttys/webui-rttys.crt
+#webui-ssl-key: /etc/rttys/webui-rttys.key
 
 #token: a1d4cdb1a3cd6a0e94aa3599afcddcf5
 


### PR DESCRIPTION
By separating the SSL configurations, we can more effectively manage security protocols tailored to the specific requirements of both the device and the user.
I have also added a boolean switch called "separate-ssl-config" to ensure that users using the old configuration can transition smoothly to the new version without any issues.
Additionally, this PR addresses a bug that prevented the configuration file from properly parsing boolean values.