### PR TITLE
feat: add disable user sign up

### DIFF
--- a/api.go
+++ b/api.go
@@ -356,6 +356,11 @@ func apiStart(br *broker) {
 			return
 		}
 
+		if cfg.DisableSignUp {
+			c.Status(http.StatusForbidden)
+			return
+		}
+
 		db, err := instanceDB(cfg.DB)
 		if err != nil {
 			log.Error().Msg(err.Error())
@@ -396,6 +401,10 @@ func apiStart(br *broker) {
 		}
 
 		c.JSON(http.StatusOK, gin.H{"admin": isAdmin})
+	})
+
+	r.GET("/allowsignup", func(c *gin.Context) {
+		c.JSON(http.StatusOK, gin.H{"allow": !cfg.DisableSignUp})
 	})
 
 	r.GET("/users", func(c *gin.Context) {

--- a/config/config.go
+++ b/config/config.go
@@ -15,6 +15,7 @@ type Config struct {
 	AddrDev           string
 	AddrUser          string
 	AddrHttpProxy     string
+	DisableSignUp	   	  bool
 	HttpProxyRedirURL string
 	HttpProxyPort     int
 	SslCert           string
@@ -51,13 +52,14 @@ func Parse(c *cli.Context) *Config {
 		AddrDev:           c.String("addr-dev"),
 		AddrUser:          c.String("addr-user"),
 		AddrHttpProxy:     c.String("addr-http-proxy"),
+		DisableSignUp:      c.Bool("disable-sign-up"),
 		HttpProxyRedirURL: c.String("http-proxy-redir-url"),
 		SslCert:           c.String("ssl-cert"),
 		SslKey:            c.String("ssl-key"),
 		SslCacert:         c.String("ssl-cacert"),
 		SeparateSslConfig: c.Bool("separate-ssl-config"),
-		WebUISslCert:       c.String("webui-ssl-cert"),
-		WebUISslKey:        c.String("webui-ssl-key"),
+		WebUISslCert:      c.String("webui-ssl-cert"),
+		WebUISslKey:       c.String("webui-ssl-key"),
 		Token:             c.String("token"),
 		DB:                c.String("db"),
 		LocalAuth:         c.Bool("local-auth"),
@@ -80,6 +82,7 @@ func Parse(c *cli.Context) *Config {
 		getConfigOpt(yamlCfg, "addr-dev", &cfg.AddrDev)
 		getConfigOpt(yamlCfg, "addr-user", &cfg.AddrUser)
 		getConfigOpt(yamlCfg, "addr-http-proxy", &cfg.AddrHttpProxy)
+		getConfigOpt(yamlCfg, "disable-sign-up", &cfg.DisableSignUp)
 		getConfigOpt(yamlCfg, "http-proxy-redir-url", &cfg.HttpProxyRedirURL)
 		getConfigOpt(yamlCfg, "ssl-cert", &cfg.SslCert)
 		getConfigOpt(yamlCfg, "ssl-key", &cfg.SslKey)

--- a/rttys.conf
+++ b/rttys.conf
@@ -27,3 +27,6 @@
 # database source
 db: sqlite://rttys.db
 #db: mysql://rttys:rttys@tcp(localhost)/rttys
+
+#disable new user sign up
+#disable-sign-up: True

--- a/ui/src/views/Login.vue
+++ b/ui/src/views/Login.vue
@@ -12,7 +12,7 @@
       </FormItem>
     </Form>
     <p v-if="signup" style="text-align: center">{{ $t('Already have an account?') }}<a href="/login" style="text-decoration: none; color: #1c7cd6">{{ $t('Sign in') }}</a></p>
-    <p v-else style="text-align: center">{{ $t('New to Rttys?') }}<a href="/login?signup=1" style="text-decoration: none; color: #1c7cd6">{{ $t('Sign up') }}</a></p>
+    <p v-else-if="allowSignup" style="text-align: center">{{ $t('New to Rttys?') }}<a href="/login?signup=1" style="text-decoration: none; color: #1c7cd6">{{ $t('Sign up') }}</a></p>
   </Card>
 </template>
 
@@ -22,7 +22,8 @@ export default {
   data() {
     return {
       signup: false,
-        formData: {
+      allowSignup: false,
+      formData: {
         username: '',
         password: ''
       },
@@ -65,6 +66,11 @@ export default {
   created() {
     this.signup = this.$route.query.signup === '1';
     sessionStorage.removeItem('rttys-sid');
+    this.axios.get('/allowsignup').then(response => {
+      this.allowSignup = response.data.allow;
+    }).catch(() => {
+      this.allowSignup = false;
+    });
   }
 }
 </script>


### PR DESCRIPTION
An option to disable user registration has been added. When registration is turned off, the signup API will be disabled, and the registration option will not be displayed in the web UI.